### PR TITLE
Fix bug with `update-alternatives`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,10 @@ RUN cd /tmp && \
     echo '86a3b4673ce78663ab996aa542a2bd93f9e666f04e16f4763cccfba6274beb04  AutoFirma_Linux_Fedora.zip' | sha256sum --check --status && \
     unzip AutoFirma_Linux_Fedora.zip && \
     rpm-ostree install java-17-openjdk && \
+    for bin in /usr/lib/jvm/java-17-openjdk*/bin/*; do \
+        ln -s "${bin}" /etc/alternatives/ && \
+        ln -s /etc/alternatives/"$(basename "${bin}")" /usr/bin/; \
+    done && \
     rpm-ostree install autofirma-*.noarch_FEDORA.rpm configuradorfnmt-*.x86_64.rpm && \
     rpm-ostree cleanup -m && \
     ostree container commit


### PR DESCRIPTION
Use `/etc/alternatives` instead of `/var/lib/alternatives` to avoid error message:

	admindir /var/lib/alternatives invalid